### PR TITLE
Add time and datetime (ISO8601) example to specification.

### DIFF
--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -57,7 +57,9 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 * Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be numerical, e.g. `ses-01`.
 * Sessions *should* be assigned ascending numerical labels as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s for consistent indentation and sorting, e.g. `ses-01`, `ses-02`, `ses-03`.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `ses` key-value pair. For example, dates can be added as follows: `ses-001_date-20230310`. The keys *should* be consistent across subjects.
-* If a date field is added, it *should* be in the format `YYYYMMDD`.
+* If a `date` field is added, it *should* be in the format `YYYYMMDD`.
+* If a `time` field is added, it *should* be in the format `HHMMSS`
+* If a `datetime` field is added, it *should* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` e.g. `20231225T133015`.
 * Different sessions *may* contain different combinations of datatypes.
 
 :::{hint}


### PR DESCRIPTION
closes #32. This PR adds an example for `time` and `datetime` keys to indicate how they should be formatted. In the case of `datetime` this is suggested to be ISO8601, let me know if these are not clear.

Currently, the formatting of dates / times / datimes is *should*. Shall we change it to *must*? I think it will be easier to hard-specifcy a time / date format with little overhead for reserachers.