### PR TITLE
Fix broken link to NeuroBlueprint specification in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `NeuroBlueprint` is a folder structure specification for (systems) neuroscience research projects. It is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/), widely used in human neuroimaging.
 
-The [NeuroBlueprint specification](specification.md) provides a set of rules and guidelines for project folder organisation, ensuring consistent data management within and between labs. The focus is on ensuring minimal overhead for researchers.
+The [NeuroBlueprint specification](https://neuroblueprint.neuroinformatics.dev/specification.html) provides a set of rules and guidelines for project folder organisation, ensuring consistent data management within and between labs. The focus is on ensuring minimal overhead for researchers.
 
 `NeuroBlueprint` is being developed at the [Sainsbury Wellcome Centre (SWC) for Neural Circuits and Behaviour](https://www.sainsburywellcome.org/) by members of the [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/). As such, it prioritizes interoperability with NIU-developed data analysis tools.
 


### PR DESCRIPTION
Steve noticed a link in the README to the specification was broken. Instead of the github spec I linked to the website, but maybe it is better to re-link to the specification.md on github?

