### PR TITLE
Deploy website only when a release is made

### DIFF
--- a/.github/workflows/docs_build_and_deploy.yml
+++ b/.github/workflows/docs_build_and_deploy.yml
@@ -2,9 +2,8 @@ name: Build Sphinx docs and deploy to GitHub Pages
 
 # Generate the documentation on all merges to main, all pull requests, or by
 # manual workflow dispatch. The build job can be used as a CI check that the
-# docs still build successfully. The deploy job only runs when merging
-# to main and actually moves the generated html to the gh-pages branch
-# (which triggers a GitHub pages deployment).
+# docs still build successfully. The deploy job only runs when a tag is pushed
+# (so, when a new release is made).
 on:
   push:
     branches:
@@ -38,7 +37,7 @@ jobs:
     needs: build_sphinx_docs
     permissions:
       contents: write
-    if: github.event_name == 'push' && github.ref_name == 'main'
+    if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: neuroinformatics-unit/actions/deploy_sphinx_docs@v2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,6 @@ myst-parser
 nbsphinx
 numpydoc
 pydata-sphinx-theme
+setuptools-scm
 sphinx
 sphinx-design

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,13 +16,20 @@
 
 
 # -- Project information -----------------------------------------------------
+import setuptools_scm
 
 project = 'NeuroBlueprint'
 copyright = '2022, UCL'
 author = 'Neuroinformatics Unit'
 
-# The full version, including alpha/beta/rc tags
-release = '0.1.0'
+# Retrieve the version number from the package
+try:
+    release = setuptools_scm.get_version(root="../..", relative_to=__file__)
+    release = release.split(".dev")[0]  # remove dev tag and git hash
+except LookupError:
+    # if git is not initialised, still allow local build
+    # with a dummy version
+    release = "0.0.0"
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
From now on, the website will only deploy when we make a new release (with a tag present).
The current version will be fetched via `setuptools-scm` and displayed on the website.