### PR TITLE
Fix zulip links.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -120,7 +120,18 @@ html_theme_options = {
             "icon": "fa-brands fa-github",
             # The type of image to be used (see below for details)
             "type": "fontawesome",
-        }
+        },
+        {
+            # Label for this link
+            "name": "Zulip (chat)",
+            # URL where the link will redirect
+            "url": "https://neuroinformatics.zulipchat.com/#narrow/stream/406000-SWC-Blueprint",  # required
+            # Icon class (if "type": "fontawesome"), or path to local image (if
+            # "type": "local")
+            "icon": "fa-solid fa-comments",
+            # The type of image to be used (see below for details)
+            "type": "fontawesome",
+        },
     ],
     "logo": {
         "text": f"NeuroBlueprint v{release}",

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -3,13 +3,21 @@
 <img src="_static/NeuroBlueprint_logo-light_no-text.png" alt="NeuroBlueprint logo" class="only-light img-responsive"/>
 <img src="_static/NeuroBlueprint_logo-dark_no-text.png" alt="NeuroBlueprint logo" class="only-dark img-responsive"/>
 
-**NeuroBlueprint** is a folder structure specification for (systems) neuroscience research projects. It is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/), widely used in human neuroimaging.
+**NeuroBlueprint** is a folder structure specification for (systems) neuroscience research projects. It is inspired by, 
+and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/), widely used in human neuroimaging.
 
-The [NeuroBlueprint specification](specification.md) provides a set of rules and guidelines for project folder organisation, ensuring consistent data management within and between labs. The focus is on ensuring minimal overhead for researchers.
+The [NeuroBlueprint specification](specification.md) provides a set of rules and guidelines for project folder organisation, 
+ensuring consistent data management within and between labs. The focus is on ensuring minimal overhead for researchers.
 
-**NeuroBlueprint** is being developed at the [Sainsbury Wellcome Centre (SWC) for Neural Circuits and Behaviour](https://www.sainsburywellcome.org/) by members of the [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/). As such, it prioritizes interoperability with NIU-developed data analysis tools.
+**NeuroBlueprint** is being developed at the [Sainsbury Wellcome Centre (SWC) for Neural Circuits and Behaviour](https://www.sainsburywellcome.org/) 
+by members of the [Neuroinformatics Unit (NIU)](https://neuroinformatics.dev/). As such, it prioritizes interoperability with NIU-developed data analysis tools.
 
-That said, the specification is designed to be as general as possible, and should be useful to anyone within the neuroscience field. We (the NIU) welcome feedback and contributions from the wider community and commit to maintaining the specification as a living and evolving document. Check out the NeuroBlueprint [Zulip chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-SWC-Blueprint) or raise a [GitHub Issue](https://github.com/neuroinformatics-unit/NeuroBlueprint/issues) to get in touch. To chat about the specification, you can join the [NeuroBlueprint Zulip chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-SWC-Blueprint). We will also collaborate with [ongoing efforts](https://github.com/INCF/neuroscience-data-structure) by the [INCF](https://www.incf.org/) and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS specification to non-human animal research.
+That said, the specification is designed to be as general as possible, and should be useful to anyone within the neuroscience field. 
+We (the NIU) welcome feedback and contributions from the wider community and commit to maintaining the specification as a living and evolving document. 
+Check out the NeuroBlueprint [Zulip chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-SWC-Blueprint) or 
+raise a [GitHub Issue](https://github.com/neuroinformatics-unit/NeuroBlueprint/issues) to get in touch. 
+We will also collaborate with [ongoing efforts](https://github.com/INCF/neuroscience-data-structure) by the [INCF](https://www.incf.org/) 
+and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS specification to non-human animal research.
 
 ```{toctree}
 :maxdepth: 3


### PR DESCRIPTION
This PR closes #35, removing the dulpicate reference to the chat and adding the icon in the top right. I did this as opened the original PR but didn't realise it had been assigned, apologies hope this does not duplicate any work!