### PR TITLE
Add 'Community' section.

### DIFF
--- a/docs/source/community.md
+++ b/docs/source/community.md
@@ -15,10 +15,8 @@ We are keen to work closely with ongoing standardisation efforts in the
 and
 [NWB](https://www.nwb.org)
 communities. Please see our
-[Guiding Principles](https://datashuttle.neuroinformatics.dev/pages/community/guiding-principles.html)
-and
 [Roadmap](roadmap.md)
-for more details on our future plans.
+for details on our future plans.
 
 ```{toctree}
 :maxdepth: 3

--- a/docs/source/community.md
+++ b/docs/source/community.md
@@ -1,22 +1,25 @@
 # Community
 
 NeuroBlueprint is developed by the
-[NeuroInformatics Unit]()
+[NeuroInformatics Unit](https://neuroinformatics.dev)
 at the Sainsbury Wellcome Centre.
 
-We are keen for feedback on the standard and
-encourage feedback through [GitHub Issues]()
+We are keen for feedback on the standard and encourage feedback through 
+[GitHub Issues](https://github.com/neuroinformatics-unit/NeuroBlueprint)
 or on our
-[Zulip Chat]().
+[Zulip Chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-NeuroBlueprint).
 
-We are keen to work closely with ongoing
-standardisation efforts in the
-[BIDS]()
+We are keen to work closely with ongoing standardisation efforts in the
+[BIDS](https://bids.neuroimaging.io)
 and
-[NWB]() communities.
+[NWB](https://www.nwb.org) 
+communities.
 
-Please see our [Guiding Principles]()  (LINK TO DS?)
-and [Roadmap](roadmap.md) for more details on our future plans.
+Please see our 
+[Guiding Principles](https://datashuttle.neuroinformatics.dev/pages/community/guiding-principles.html) 
+and 
+[Roadmap](roadmap.md) 
+for more details on our future plans.
 
 ```{toctree}
 :maxdepth: 3

--- a/docs/source/community.md
+++ b/docs/source/community.md
@@ -1,18 +1,18 @@
 # Community
 
-NeuroBlueprint is developed by the 
+NeuroBlueprint is developed by the
 [NeuroInformatics Unit]()
 at the Sainsbury Wellcome Centre.
 
 We are keen for feedback on the standard and
 encourage feedback through [GitHub Issues]()
-or on our 
+or on our
 [Zulip Chat]().
 
 We are keen to work closely with ongoing
-standardisation efforts in the 
+standardisation efforts in the
 [BIDS]()
-and 
+and
 [NWB]() communities.
 
 Please see our [Guiding Principles]()  (LINK TO DS?)
@@ -21,7 +21,7 @@ and [Roadmap](roadmap.md) for more details on our future plans.
 ```{toctree}
 :maxdepth: 3
 :caption: Contents
-:hidden: 
+:hidden:
 
 roadmap
 ```

--- a/docs/source/community.md
+++ b/docs/source/community.md
@@ -2,23 +2,20 @@
 
 NeuroBlueprint is developed by the
 [NeuroInformatics Unit](https://neuroinformatics.dev)
-at the Sainsbury Wellcome Centre.
-
-We are keen for feedback on the standard and encourage feedback through 
+at the Sainsbury Wellcome Centre. We are very interested in feedback on the
+specification, please get in contact through our
 [GitHub Issues](https://github.com/neuroinformatics-unit/NeuroBlueprint)
-or on our
-[Zulip Chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-NeuroBlueprint).
+or
+[Zulip Chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-NeuroBlueprint)!
 
 We are keen to work closely with ongoing standardisation efforts in the
 [BIDS](https://bids.neuroimaging.io)
 and
-[NWB](https://www.nwb.org) 
-communities.
-
-Please see our 
-[Guiding Principles](https://datashuttle.neuroinformatics.dev/pages/community/guiding-principles.html) 
-and 
-[Roadmap](roadmap.md) 
+[NWB](https://www.nwb.org)
+communities. Please see our
+[Guiding Principles](https://datashuttle.neuroinformatics.dev/pages/community/guiding-principles.html)
+and
+[Roadmap](roadmap.md)
 for more details on our future plans.
 
 ```{toctree}

--- a/docs/source/community.md
+++ b/docs/source/community.md
@@ -1,0 +1,27 @@
+# Community
+
+NeuroBlueprint is developed by the 
+[NeuroInformatics Unit]()
+at the Sainsbury Wellcome Centre.
+
+We are keen for feedback on the standard and
+encourage feedback through [GitHub Issues]()
+or on our 
+[Zulip Chat]().
+
+We are keen to work closely with ongoing
+standardisation efforts in the 
+[BIDS]()
+and 
+[NWB]() communities.
+
+Please see our [Guiding Principles]()  (LINK TO DS?)
+and [Roadmap](roadmap.md) for more details on our future plans.
+
+```{toctree}
+:maxdepth: 3
+:caption: Contents
+:hidden: 
+
+roadmap
+```

--- a/docs/source/community.md
+++ b/docs/source/community.md
@@ -1,6 +1,6 @@
 # Community
 
-NeuroBlueprint is developed by the
+**NeuroBlueprint** is developed by the
 [NeuroInformatics Unit](https://neuroinformatics.dev)
 at the Sainsbury Wellcome Centre. We are very interested in feedback on the
 specification, please get in contact through our

--- a/docs/source/community.md
+++ b/docs/source/community.md
@@ -6,7 +6,7 @@ at the
 [Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/).
 We are very interested in feedback on the
 specification, please get in contact through our
-[GitHub Issues](https://github.com/neuroinformatics-unit/NeuroBlueprint)
+[GitHub Issues](https://github.com/neuroinformatics-unit/NeuroBlueprint/issues)
 or
 [Zulip Chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-NeuroBlueprint)!
 

--- a/docs/source/community.md
+++ b/docs/source/community.md
@@ -2,7 +2,9 @@
 
 **NeuroBlueprint** is developed by the
 [NeuroInformatics Unit](https://neuroinformatics.dev)
-at the Sainsbury Wellcome Centre. We are very interested in feedback on the
+at the
+[Sainsbury Wellcome Centre](https://www.sainsburywellcome.org/web/).
+We are very interested in feedback on the
 specification, please get in contact through our
 [GitHub Issues](https://github.com/neuroinformatics-unit/NeuroBlueprint)
 or

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -29,4 +29,6 @@ and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS specifica
 :caption: Contents
 
 specification
+community
 ```
+

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -31,4 +31,3 @@ and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS specifica
 specification
 community
 ```
-

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -11,7 +11,7 @@ The aim of **NeuroBlueprint**
 [v0.2](https://github.com/neuroinformatics-unit/NeuroBlueprint/releases)
 was to provide a lightweight specification
 enabling automatic discovery of raw data for
-different data types (e.g., behavior, electrophysiology).
+different data types (e.g. behaviour, electrophysiology).
 
 Next, we plan to extend the specification to support automated
 multimodal analysis. This will require metadata standardisation,

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -5,7 +5,7 @@ contains our development plans for the specification.
 It is closely aligned with the
 [**datashuttle** roadmap](https://datashuttle.neuroinformatics.dev/pages/community/roadmap.html)
 and our
-[Guiding Principles](https://datashuttle.neuroinformatics.dev/pages/community/guiding-principles.html)
+[Guiding Principles](https://datashuttle.neuroinformatics.dev/pages/community/guiding-principles.html).
 
 The roadmap is responsive to the requirements
 of the community, and we encourage people to get in
@@ -13,7 +13,7 @@ contact to outline their needs and priorities.
 
 The aim of **NeuroBlueprint**
 [v0.2](https://github.com/neuroinformatics-unit/NeuroBlueprint/releases)
-is to provide a lightweight specification
+was to provide a lightweight specification
 enabling automatic discovery of raw data for
 different data types (e.g., behavior, electrophysiology).
 
@@ -27,7 +27,6 @@ set of required keywords.
 - Investigate and adopt a metadata standard (e.g.
 [Brain Imaging Data Structure](https://bids-specification.readthedocs.io/en/stable/derivatives/common-data-types.html)
 or
-[Allen Institute for Neural Dynamics](https://github.com/AllenNeuralDynamics/aind-data-schema)
-)
+[Allen Institute for Neural Dynamics](https://github.com/AllenNeuralDynamics/aind-data-schema)).
 - Add required metadata for automated multimodal behavioural and electrophysiological
 analysis to the specification.

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -11,8 +11,9 @@ The roadmap is responsive to the requirements
 of the community and we encourage people to get in
 contact to outline their needs and priorities.
 
-The aim of NeuroBlueprint v2.0 was to
-provide a lightweight specification
+The aim of NeuroBlueprint
+[v0.2](https://github.com/neuroinformatics-unit/NeuroBlueprint/releases)
+is to provide a lightweight specification
 enabling automatic discovery of raw data and
 derivatives for different data types (e.g., behavior, electrophysiology).
 
@@ -21,10 +22,12 @@ multimodal analysis. This will require metadata standardisation,
 and we will decide on an existing metadata standard to adopt and minimal
 set of required keywords.
 
-**Q3 2024**
-
-- Investigate and adopt a metadata standard (e.g. BIDS or Allen AIND)
-
 **Q4 2024**
 
-- Add required metadata for automated multimodal behavioural and electrophysiological analysis to the specification.
+- Investigate and adopt a metadata standard (e.g.
+[Brain Imaging Data Structure](https://bids-specification.readthedocs.io/en/stable/derivatives/common-data-types.html)
+or
+[Allen Institute for Neural Dynamics](https://github.com/AllenNeuralDynamics/aind-data-schema)
+)
+- Add required metadata for automated multimodal behavioural and electrophysiological
+analysis to the specification.

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -1,0 +1,30 @@
+# Roadmap
+
+The roadmap for NeuroBlueprint
+contains our development plans for the package.
+It is closely aligned with 
+[datashuttle roadmap]()
+and our 
+[guiding principles](). 
+
+The roadmap is responsive to the requirements
+of the community and we encourage people to get in
+contact to outline their needs and priorities.
+
+The aim of NeuroBlueprint v2.0 was to 
+provide a lightweight specification 
+enabling automatic discovery of raw data and 
+derivatives for different data types (e.g., behavior, electrophysiology).
+
+Next, we plan to extend the specification to support automated 
+multimodal analysis. This will require metadata standardisation,
+and we will decide on an existing metadata standard to adopt and minimal
+set of required keywords.
+
+**Q3 2024**
+
+- Investigate and adopt a metadata standard (e.g. BIDS or Allen AIND)
+
+**Q4 2024**
+
+- Add required metadata for automated multimodal behavioural and electrophysiolgical analysis to the specification. 

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -15,7 +15,7 @@ different data types (e.g., behavior, electrophysiology).
 
 Next, we plan to extend the specification to support automated
 multimodal analysis. This will require metadata standardisation,
-and we will decide on an existing metadata standard to adopt and minimal
+and we will decide on an existing metadata standard to adopt and a minimal
 set of required keywords.
 
 **Q4 2024**

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -1,21 +1,21 @@
 # Roadmap
 
-The roadmap for NeuroBlueprint
+The roadmap for **NeuroBlueprint**
 contains our development plans for the specification.
-It is closely aligned with
-[datashuttle roadmap](https://datashuttle.neuroinformatics.dev/pages/community/roadmap.html)
+It is closely aligned with the
+[**datashuttle** roadmap](https://datashuttle.neuroinformatics.dev/pages/community/roadmap.html)
 and our
 [Guiding Principles](https://datashuttle.neuroinformatics.dev/pages/community/guiding-principles.html)
 
 The roadmap is responsive to the requirements
-of the community and we encourage people to get in
+of the community, and we encourage people to get in
 contact to outline their needs and priorities.
 
-The aim of NeuroBlueprint
+The aim of **NeuroBlueprint**
 [v0.2](https://github.com/neuroinformatics-unit/NeuroBlueprint/releases)
 is to provide a lightweight specification
-enabling automatic discovery of raw data and
-derivatives for different data types (e.g., behavior, electrophysiology).
+enabling automatic discovery of raw data for
+different data types (e.g., behavior, electrophysiology).
 
 Next, we plan to extend the specification to support automated
 multimodal analysis. This will require metadata standardisation,

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -3,9 +3,9 @@
 The roadmap for NeuroBlueprint
 contains our development plans for the specification.
 It is closely aligned with
-[datashuttle roadmap]()
+[datashuttle roadmap](https://datashuttle.neuroinformatics.dev/pages/community/roadmap.html)
 and our
-[guiding principles]().
+[Guiding Principles](https://datashuttle.neuroinformatics.dev/pages/community/guiding-principles.html)
 
 The roadmap is responsive to the requirements
 of the community and we encourage people to get in

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -1,7 +1,7 @@
 # Roadmap
 
 The roadmap for NeuroBlueprint
-contains our development plans for the package.
+contains our development plans for the specification.
 It is closely aligned with
 [datashuttle roadmap]()
 and our

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -27,4 +27,4 @@ set of required keywords.
 
 **Q4 2024**
 
-- Add required metadata for automated multimodal behavioural and electrophysiolgical analysis to the specification.
+- Add required metadata for automated multimodal behavioural and electrophysiological analysis to the specification.

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -2,21 +2,21 @@
 
 The roadmap for NeuroBlueprint
 contains our development plans for the package.
-It is closely aligned with 
+It is closely aligned with
 [datashuttle roadmap]()
-and our 
-[guiding principles](). 
+and our
+[guiding principles]().
 
 The roadmap is responsive to the requirements
 of the community and we encourage people to get in
 contact to outline their needs and priorities.
 
-The aim of NeuroBlueprint v2.0 was to 
-provide a lightweight specification 
-enabling automatic discovery of raw data and 
+The aim of NeuroBlueprint v2.0 was to
+provide a lightweight specification
+enabling automatic discovery of raw data and
 derivatives for different data types (e.g., behavior, electrophysiology).
 
-Next, we plan to extend the specification to support automated 
+Next, we plan to extend the specification to support automated
 multimodal analysis. This will require metadata standardisation,
 and we will decide on an existing metadata standard to adopt and minimal
 set of required keywords.
@@ -27,4 +27,4 @@ set of required keywords.
 
 **Q4 2024**
 
-- Add required metadata for automated multimodal behavioural and electrophysiolgical analysis to the specification. 
+- Add required metadata for automated multimodal behavioural and electrophysiolgical analysis to the specification.

--- a/docs/source/roadmap.md
+++ b/docs/source/roadmap.md
@@ -2,10 +2,6 @@
 
 The roadmap for **NeuroBlueprint**
 contains our development plans for the specification.
-It is closely aligned with the
-[**datashuttle** roadmap](https://datashuttle.neuroinformatics.dev/pages/community/roadmap.html)
-and our
-[Guiding Principles](https://datashuttle.neuroinformatics.dev/pages/community/guiding-principles.html).
 
 The roadmap is responsive to the requirements
 of the community, and we encourage people to get in
@@ -27,8 +23,7 @@ set of required keywords.
 - Investigate and adopt a metadata standard (e.g.
 [Brain Imaging Data Structure](https://bids-specification.readthedocs.io/en/stable/derivatives/common-data-types.html)
 or
-[Allen Institute for Neural Dynamics](https://github.com/AllenNeuralDynamics/aind-data-schema)
-).
+[Allen Institute for Neural Dynamics](https://github.com/AllenNeuralDynamics/aind-data-schema)).
 
 - Add required metadata for automated multimodal behavioural and electrophysiological
 analysis to the specification.


### PR DESCRIPTION
This PR adds a community section giving some contact details of NIU (and general standardisation community). It also adds a N.B specific roadmap. This is currently a draft PR to support other discussions on roadmaps (e.g. [here](https://github.com/neuroinformatics-unit/neuroinformatics-unit.github.io/pull/99/files)).

TODO:
The datashuttle website has the 'guiding principles' that the NB roadmap should link to. Also the datashuttle and NB roadmaps should link to eachother. For now I have linked here to what the datashuttle link is expected to be. I think the non-real link will result in build error. Once datashuttle community section is merged, we can then publish this. Then we can go back and do a quick release to add datashuttle links to NB? Maybe there is a better way to link related projects with sphinx.