### PR TITLE
Add emg as a narrow datatype

### DIFF
--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -103,6 +103,7 @@ please get in contact!
 **ephys**
 - `ecephys`: extracellular electrophysiology
 - `icephys`: intracellular electrophysiology
+- `emg`: electromyography
 
 **funcimg**
 - `cscope`: head-mounted widefield macroscope


### PR DESCRIPTION
This PR adds `emg` (electromyography) as a narrow datatype under `ephys`.