### PR TITLE
Small changes to the overview section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 ![](docs/source/_static/NeuroBlueprint_logo-dark_no-text.png)
 
 `NeuroBlueprint` is a folder structure specification for (systems) neuroscience research projects.
-It is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/),
-widely used in human neuroimaging.
-
 The [NeuroBlueprint specification](https://neuroblueprint.neuroinformatics.dev/specification.html) provides
 a set of rules and guidelines for project folder organisation, ensuring consistent data management within and
 between labs. The focus is on ensuring minimal overhead for researchers.
@@ -26,7 +23,9 @@ We (the NIU) welcome feedback and contributions
 from the wider community and commit to maintaining the specification as a living and evolving document.
 Check out the NeuroBlueprint [Zulip chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-NeuroBlueprint)
 or raise a [GitHub Issue](https://github.com/neuroinformatics-unit/NeuroBlueprint/issues) to get in touch.
-We will also collaborate with [ongoing efforts](https://github.com/INCF/neuroscience-data-structure) by
+
+`NeuroBlueprint` is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/),
+widely used in human neuroimaging. We will collaborate with [ongoing efforts](https://github.com/INCF/neuroscience-data-structure) by
 the [INCF](https://www.incf.org/) and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS
 specification to non-human animal research.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![](docs/source/_static/NeuroBlueprint_logo-dark_no-text.png)
 
 `NeuroBlueprint` is a folder structure specification for (systems) neuroscience research projects.
-The [NeuroBlueprint specification](https://neuroblueprint.neuroinformatics.dev/specification.html) provides
-a set of rules and guidelines for project folder organisation, ensuring consistent data management within and
+It provides a set of [rules and guidelines](https://neuroblueprint.neuroinformatics.dev/specification.html)
+for project folder organisation, ensuring consistent data management within and
 between labs. The focus is on ensuring minimal overhead for researchers.
 
 `NeuroBlueprint` is being developed at the

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -3,9 +3,7 @@
 <img src="_static/NeuroBlueprint_logo-light_no-text.png" alt="NeuroBlueprint logo" class="only-light img-responsive"/>
 <img src="_static/NeuroBlueprint_logo-dark_no-text.png" alt="NeuroBlueprint logo" class="only-dark img-responsive"/>
 
-**NeuroBlueprint** is a folder structure specification for (systems) neuroscience research projects. It is inspired by,
-and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/), widely used in human neuroimaging.
-
+**NeuroBlueprint** is a folder structure specification for (systems) neuroscience research projects.
 The [NeuroBlueprint specification](specification.md) provides a set of rules and guidelines for project folder organisation,
 ensuring consistent data management within and between labs. The focus is on ensuring minimal overhead for researchers.
 
@@ -19,10 +17,10 @@ into data acquisition workflows and automates the creation and transfer
 of **NeuroBlueprint**-compliant folders.
 
 We (the NIU) welcome feedback and contributions from the wider community and commit to maintaining the specification as a living and evolving document.
-Check out the NeuroBlueprint [Zulip chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-NeuroBlueprint) or
-raise a [GitHub Issue](https://github.com/neuroinformatics-unit/NeuroBlueprint/issues) to get in touch.
-We will also collaborate with [ongoing efforts](https://github.com/INCF/neuroscience-data-structure) by the [INCF](https://www.incf.org/)
-and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS specification to non-human animal research.
+Check out the NeuroBlueprint [Zulip chat](https://neuroinformatics.zulipchat.com/#narrow/stream/406000-NeuroBlueprint) or raise a [GitHub Issue](https://github.com/neuroinformatics-unit/NeuroBlueprint/issues) to get in touch.
+
+**NeuroBlueprint** is inspired by, and based on the [BIDS specification](https://bids-specification.readthedocs.io/en/stable/), widely used in human neuroimaging.
+We will collaborate with [ongoing efforts](https://github.com/INCF/neuroscience-data-structure) by the [INCF](https://www.incf.org/) and [BIDS community](https://bids.neuroimaging.io/) to extend the BIDS specification to non-human animal research.
 
 ```{toctree}
 :maxdepth: 3

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,7 +4,7 @@
 <img src="_static/NeuroBlueprint_logo-dark_no-text.png" alt="NeuroBlueprint logo" class="only-dark img-responsive"/>
 
 **NeuroBlueprint** is a folder structure specification for (systems) neuroscience research projects.
-The [NeuroBlueprint specification](specification.md) provides a set of rules and guidelines for project folder organisation,
+It provides a set of [rules and guidelines](specification.md) for project folder organisation,
 ensuring consistent data management within and between labs. The focus is on ensuring minimal overhead for researchers.
 
 **NeuroBlueprint** is being developed at the [Sainsbury Wellcome Centre (SWC) for Neural Circuits and Behaviour](https://www.sainsburywellcome.org/)


### PR DESCRIPTION
This PR makes a small change to the overview, moving the section on BIDS to the end where we already discuss BIDS. A benefit of this is it is not confusing for those who have not heard of BIDS. 

Also, an ulterior motive for this PR is to enable a release (`v0.3.3`) to mint a Zenodo DOI.

Also, on the website do you think it is worth changing the bold **NeuroBlueprint** to backticked `NeuroBlueprint`? It's not a code package I guess so it makes less sense, but not sure if the bold looks a bit odd.