### PR TITLE
Extend datetime requirements.

### DIFF
--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -57,7 +57,7 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 * Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be numerical, e.g. `ses-01`.
 * Sessions *should* be assigned ascending numerical labels as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s for consistent indentation and sorting, e.g. `ses-01`, `ses-02`, `ses-03`.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `ses` key-value pair. For example, dates can be added as follows: `ses-001_date-20230310`. The keys *should* be consistent across subjects.
-* If a date, time or datetime is added, it *must* be in [ISO8610](https://en.wikipedia.org/wiki/ISO_8601) format and *should* be paired with a `date-`, `time-` or `datetime-` key, respectively. For example:
+* If a date, time or datetime is added, it *must* be in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format and *should* be paired with a `date-`, `time-` or `datetime-` key, respectively. For example:
  - date: `ses-001_date-20250101` (date format YYYYMMDD)
  - time: `ses-001_time-140101` (time format HHMMSS)
  - datetime: `ses-001_datetime-20250101T140101` (datetime format YYYYMMDDTHHMMSS)

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -57,9 +57,9 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 * Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be numerical, e.g. `ses-01`.
 * Sessions *should* be assigned ascending numerical labels as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s for consistent indentation and sorting, e.g. `ses-01`, `ses-02`, `ses-03`.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `ses` key-value pair. For example, dates can be added as follows: `ses-001_date-20230310`. The keys *should* be consistent across subjects.
-* If a `date` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDD` and *should* be paired with a `date-` key e.g. `date-20250101`.
-* If a `time` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `HHMMSS` and *should* be paired with a `time-` key e.g. `time-181210`.
-* If a `datetime` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` and *should* be paired with a `datetime` key e.g. `datetime-20231225T133015`.
+* If a date value is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDD` and *should* be paired with a `date-` key e.g. `date-20250101`.
+* If a time value is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `HHMMSS` and *should* be paired with a `time-` key e.g. `time-181210`.
+* If a datetime value is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` and *should* be paired with a `datetime` key e.g. `datetime-20231225T133015`.
 * Different sessions *may* contain different combinations of datatypes.
 
 :::{hint}

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -57,9 +57,9 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 * Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be numerical, e.g. `ses-01`.
 * Sessions *should* be assigned ascending numerical labels as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s for consistent indentation and sorting, e.g. `ses-01`, `ses-02`, `ses-03`.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `ses` key-value pair. For example, dates can be added as follows: `ses-001_date-20230310`. The keys *should* be consistent across subjects.
-* If a `date` field is added, it *should* be in the format `YYYYMMDD`.
-* If a `time` field is added, it *should* be in the format `HHMMSS`
-* If a `datetime` field is added, it *should* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` e.g. `20231225T133015`.
+* If a `date` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDD` and *should* be paired with a `date-` key e.g. `date-20250101`.
+* If a `time` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `HHMMSS` and *should* be paired with a `time-` key e.g. `time-181210`.
+* If a `datetime` field is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` and *should* be paired with a `datetime` key e.g. `datetime-20231225T133015`.
 * Different sessions *may* contain different combinations of datatypes.
 
 :::{hint}

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -57,9 +57,11 @@ Below we describe each level of the `rawdata` folder hierarchy in more detail. T
 * Session-level folders *must* be prefixed with a key-value pair that is unique for each session. The key *must* be `ses` and the value *must* be numerical, e.g. `ses-01`.
 * Sessions *should* be assigned ascending numerical labels as they are added to the project. The labels *should* be prefixed with an arbitrary number of 0s for consistent indentation and sorting, e.g. `ses-01`, `ses-02`, `ses-03`.
 * Additional key-value pairs with alphanumerical labels *may* be appended after the `ses` key-value pair. For example, dates can be added as follows: `ses-001_date-20230310`. The keys *should* be consistent across subjects.
-* If a date value is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDD` and *should* be paired with a `date-` key e.g. `date-20250101`.
-* If a time value is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `HHMMSS` and *should* be paired with a `time-` key e.g. `time-181210`.
-* If a datetime value is added, it *must* be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format `YYYYMMDDTHHMMSS` and *should* be paired with a `datetime` key e.g. `datetime-20231225T133015`.
+* If a date, time or datetime is added, it *must* be in [ISO8610](https://en.wikipedia.org/wiki/ISO_8601) format and *should* be paired with a `date-`, `time-` or `datetime-` key, respectively. For example:
+ - date: `ses-001_date-20250101` (date format YYYYMMDD)
+ - time: `ses-001_time-140101` (time format HHMMSS)
+ - datetime: `ses-001_datetime-20250101T140101` (datetime format YYYYMMDDTHHMMSS)
+
 * Different sessions *may* contain different combinations of datatypes.
 
 :::{hint}


### PR DESCRIPTION
Related to #31 #74 this PR enforces that any date / time / datetimes are in ISO8601 format (previously this was suggested). It also makes it clearer that using `date-`, `time-` or `datetime-` keys is recommended but not mandated (combined with #75 this would allow their use as `sub-` or `ses-` labels as discussed in #74 @glopesdev).

This PR changes the specification and requires no tests or further documentation.
 